### PR TITLE
feat: template type and configuration fields for template default params and schema

### DIFF
--- a/src/main/java/com/amazon/aws/iot/greengrass/component/common/ComponentConfiguration.java
+++ b/src/main/java/com/amazon/aws/iot/greengrass/component/common/ComponentConfiguration.java
@@ -24,13 +24,7 @@ public class ComponentConfiguration {
 
     JsonNode defaultConfiguration;
 
-    JsonNode defaultParameters;
-
     Map<String, TemplateParameter> parameterSchema;
-
-    public ComponentConfiguration(JsonNode defaultConfiguration) {
-        this.defaultConfiguration = defaultConfiguration;
-    }
 
     @JsonPOJOBuilder(withPrefix = "")
     public static class ComponentConfigurationBuilder {

--- a/src/main/java/com/amazon/aws/iot/greengrass/component/common/ComponentConfiguration.java
+++ b/src/main/java/com/amazon/aws/iot/greengrass/component/common/ComponentConfiguration.java
@@ -13,8 +13,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Map;
-
 @Data
 @Builder
 @NoArgsConstructor
@@ -23,8 +21,6 @@ import java.util.Map;
 public class ComponentConfiguration {
 
     JsonNode defaultConfiguration;
-
-    Map<String, TemplateParameter> parameterSchema;
 
     @JsonPOJOBuilder(withPrefix = "")
     public static class ComponentConfigurationBuilder {

--- a/src/main/java/com/amazon/aws/iot/greengrass/component/common/ComponentRecipe.java
+++ b/src/main/java/com/amazon/aws/iot/greengrass/component/common/ComponentRecipe.java
@@ -50,6 +50,10 @@ public class ComponentRecipe {
 
     ComponentConfiguration componentConfiguration;
 
+    Map<String, TemplateParameter> parameterSchema;
+
+    Map<String, Object> parameters;
+
     Map<String, DependencyProperties> componentDependencies;
 
     List<PlatformSpecificManifest> manifests;

--- a/src/main/java/com/amazon/aws/iot/greengrass/component/common/ComponentRecipe.java
+++ b/src/main/java/com/amazon/aws/iot/greengrass/component/common/ComponentRecipe.java
@@ -50,9 +50,9 @@ public class ComponentRecipe {
 
     ComponentConfiguration componentConfiguration;
 
-    Map<String, TemplateParameter> parameterSchema;
+    Map<String, TemplateParameter> templateParameterSchema;
 
-    Map<String, Object> parameters;
+    Map<String, Object> templateParameters;
 
     Map<String, DependencyProperties> componentDependencies;
 

--- a/src/main/java/com/amazon/aws/iot/greengrass/component/common/ComponentType.java
+++ b/src/main/java/com/amazon/aws/iot/greengrass/component/common/ComponentType.java
@@ -12,6 +12,8 @@ public enum ComponentType {
     GENERIC,
     @JsonProperty("aws.greengrass.lambda")
     LAMBDA,
+    @JsonProperty("aws.greengrass.template")
+    TEMPLATE,
     @JsonProperty("aws.greengrass.plugin")
     PLUGIN,
     @JsonProperty("aws.greengrass.nucleus")

--- a/src/main/java/com/amazon/aws/iot/greengrass/component/common/TemplateParameter.java
+++ b/src/main/java/com/amazon/aws/iot/greengrass/component/common/TemplateParameter.java
@@ -26,6 +26,8 @@ public class TemplateParameter {
     @Builder.Default
     Boolean required = false;
 
+    Object defaultValue;
+
     @JsonPOJOBuilder(withPrefix = "")
     public static class TemplateParameterBuilder {
     }

--- a/src/main/java/com/amazon/aws/iot/greengrass/component/common/TemplateParameter.java
+++ b/src/main/java/com/amazon/aws/iot/greengrass/component/common/TemplateParameter.java
@@ -5,34 +5,28 @@
 
 package com.amazon.aws.iot.greengrass.component.common;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.Map;
+import lombok.NonNull;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonDeserialize(builder = ComponentConfiguration.ComponentConfigurationBuilder.class)
-public class ComponentConfiguration {
+@JsonDeserialize(builder = TemplateParameter.TemplateParameterBuilder.class)
+public class TemplateParameter {
+    @NonNull
+    TemplateParameterType type;
 
-    JsonNode defaultConfiguration;
-
-    JsonNode defaultParameters;
-
-    Map<String, TemplateParameter> parameterSchema;
-
-    public ComponentConfiguration(JsonNode defaultConfiguration) {
-        this.defaultConfiguration = defaultConfiguration;
-    }
+    @NonNull
+    @Builder.Default
+    Boolean required = false;
 
     @JsonPOJOBuilder(withPrefix = "")
-    public static class ComponentConfigurationBuilder {
+    public static class TemplateParameterBuilder {
     }
 }

--- a/src/main/java/com/amazon/aws/iot/greengrass/component/common/TemplateParameterType.java
+++ b/src/main/java/com/amazon/aws/iot/greengrass/component/common/TemplateParameterType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.aws.iot.greengrass.component.common;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum TemplateParameterType {
+    @JsonProperty("string")
+    STRING,
+    @JsonProperty("number")
+    NUMBER,
+    @JsonProperty("object")
+    OBJECT,
+    @JsonProperty("array")
+    ARRAY,
+    @JsonProperty("boolean")
+    BOOLEAN,
+}

--- a/src/test/java/com/amazon/aws/iot/greengrass/component/common/ComponentRecipeDeserializationTest.java
+++ b/src/test/java/com/amazon/aws/iot/greengrass/component/common/ComponentRecipeDeserializationTest.java
@@ -326,7 +326,7 @@ class ComponentRecipeDeserializationTest extends BaseRecipeTest {
         verifyTemplateWithAllFields(recipe);
     }
 
-    void verifyTemplateWithAllFields(ComponentRecipe recipe) {
+    void verifyTemplateWithAllFields(ComponentRecipe recipe) throws JsonProcessingException {
         assertThat(recipe.getComponentName(), Is.is("FooTemplate"));
         assertThat(recipe.getComponentVersion().getValue(), Is.is("1.0.0"));
         assertThat(recipe.getComponentType(), Is.is(ComponentType.TEMPLATE));
@@ -346,20 +346,22 @@ class ComponentRecipeDeserializationTest extends BaseRecipeTest {
         // parameter schema
         Map<String, TemplateParameter> parameterSchemaMap = recipe.getComponentConfiguration().getParameterSchema();
         assertEquals(parameterSchemaMap.size(), 7);
-        assertEquals(parameterSchemaMap.get("field1"), new TemplateParameter(TemplateParameterType.STRING, true));
-        assertEquals(parameterSchemaMap.get("Field2"), new TemplateParameter(TemplateParameterType.STRING, false));
-        assertEquals(parameterSchemaMap.get("field3"), new TemplateParameter(TemplateParameterType.BOOLEAN, false));
-        assertEquals(parameterSchemaMap.get("Field4"), new TemplateParameter(TemplateParameterType.BOOLEAN, true));
-        assertEquals(parameterSchemaMap.get("field5"), new TemplateParameter(TemplateParameterType.OBJECT, false));
-        assertEquals(parameterSchemaMap.get("field6"), new TemplateParameter(TemplateParameterType.ARRAY, false));
-        assertEquals(parameterSchemaMap.get("field7"), new TemplateParameter(TemplateParameterType.NUMBER, false));
-
-        // default parameters
-        JsonNode defaultParametersNode = recipe.getComponentConfiguration().getDefaultParameters();
-        assertEquals(defaultParametersNode.get("Field2").asText(), "Another string");
-        assertEquals(defaultParametersNode.get("field3").asBoolean(), true);
-        assertEquals(defaultParametersNode.get("field5").getNodeType(), JsonNodeType.OBJECT);
-        assertEquals(defaultParametersNode.get("field6").getNodeType(), JsonNodeType.ARRAY);
-        assertEquals(defaultParametersNode.get("field7").asInt(), 7);
+        assertEquals(parameterSchemaMap.get("field1"),
+                TemplateParameter.builder().type(TemplateParameterType.STRING).required(true).defaultValue(null).build());
+        assertEquals(parameterSchemaMap.get("Field2"),
+                TemplateParameter.builder().type(TemplateParameterType.STRING).required(false).defaultValue("Another string").build());
+        assertEquals(parameterSchemaMap.get("field3"),
+                TemplateParameter.builder().type(TemplateParameterType.BOOLEAN).required(false).defaultValue(true).build());
+        assertEquals(parameterSchemaMap.get("Field4"),
+                TemplateParameter.builder().type(TemplateParameterType.BOOLEAN).required(true).defaultValue(null).build());
+        Object field5 = DESERIALIZER_YAML.readValue("key1: val1\n" + "key2:\n" + "  subkey1: 1\n" + "  subkey2: two",
+                Object.class);
+        assertEquals(parameterSchemaMap.get("field5"),
+                TemplateParameter.builder().type(TemplateParameterType.OBJECT).required(false).defaultValue(field5).build());
+        Object field6 = DESERIALIZER_YAML.readValue("- 1\n" + "- 2\n" + "- red\n" + "- blue", Object.class);
+        assertEquals(parameterSchemaMap.get("field6"),
+                TemplateParameter.builder().type(TemplateParameterType.ARRAY).required(false).defaultValue(field6).build());
+        assertEquals(parameterSchemaMap.get("field7"),
+                TemplateParameter.builder().type(TemplateParameterType.NUMBER).required(false).defaultValue(7).build());
     }
 }

--- a/src/test/java/com/amazon/aws/iot/greengrass/component/common/ComponentRecipeDeserializationTest.java
+++ b/src/test/java/com/amazon/aws/iot/greengrass/component/common/ComponentRecipeDeserializationTest.java
@@ -8,10 +8,8 @@ package com.amazon.aws.iot.greengrass.component.common;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
 import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsMapContaining;
 import org.hamcrest.core.Is;
@@ -346,7 +344,7 @@ class ComponentRecipeDeserializationTest extends BaseRecipeTest {
         assertThat(recipe.getComponentConfiguration(), IsNull.nullValue());
 
         // parameter schema
-        Map<String, TemplateParameter> parameterSchemaMap = recipe.getParameterSchema();
+        Map<String, TemplateParameter> parameterSchemaMap = recipe.getTemplateParameterSchema();
         assertEquals(parameterSchemaMap.size(), 7);
         assertEquals(parameterSchemaMap.get("field1"),
                 TemplateParameter.builder().type(TemplateParameterType.STRING).required(true).defaultValue(null).build());
@@ -397,11 +395,11 @@ class ComponentRecipeDeserializationTest extends BaseRecipeTest {
         assertNull(recipe.getComponentDependencies());
         assertEquals(0, recipe.getLifecycle().size());
         assertEquals(0, recipe.getManifests().size());
-        assertNull(recipe.getParameterSchema());
+        assertNull(recipe.getTemplateParameterSchema());
 
         // parameters
-        assertEquals(2, recipe.getParameters().size());
-        Map<String, Object> parameters = recipe.getParameters();
+        assertEquals(2, recipe.getTemplateParameters().size());
+        Map<String, Object> parameters = recipe.getTemplateParameters();
         assertEquals(2, parameters.get("one"));
         assertEquals("blue", parameters.get("red"));
     }

--- a/src/test/java/com/amazon/aws/iot/greengrass/component/common/TemplateParameterTest.java
+++ b/src/test/java/com/amazon/aws/iot/greengrass/component/common/TemplateParameterTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.aws.iot.greengrass.component.common;
+
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TemplateParameterTest extends BaseRecipeTest {
+    @Test
+    void GIVEN_parameter_with_illegal_type_THEN_throw_json_format_exception() {
+        String filename = "template-recipe-bad-schema-type.yaml";
+        Path recipePath = getResourcePath(filename);
+
+        assertThrows(InvalidFormatException.class, () ->
+            DESERIALIZER_YAML.readValue(new String(Files.readAllBytes(recipePath)), ComponentRecipe.class));
+    }
+}

--- a/src/test/resources/recipes/sample-parameter-file-with-all-fields.json
+++ b/src/test/resources/recipes/sample-parameter-file-with-all-fields.json
@@ -1,0 +1,12 @@
+{
+  "RecipeFormatVersion": "2020-01-25",
+  "ComponentName": "Foo",
+  "ComponentDescription": "Test parameter file for Greengrass packages",
+  "ComponentPublisher": "Me",
+  "ComponentVersion": "1.0.0",
+  "ComponentType": "aws.greengrass.generic",
+  "Parameters": {
+    "one": 2,
+    "red": "blue"
+  }
+}

--- a/src/test/resources/recipes/sample-parameter-file-with-all-fields.json
+++ b/src/test/resources/recipes/sample-parameter-file-with-all-fields.json
@@ -5,7 +5,7 @@
   "ComponentPublisher": "Me",
   "ComponentVersion": "1.0.0",
   "ComponentType": "aws.greengrass.generic",
-  "Parameters": {
+  "TemplateParameters": {
     "one": 2,
     "red": "blue"
   }

--- a/src/test/resources/recipes/sample-parameter-file-with-all-fields.yaml
+++ b/src/test/resources/recipes/sample-parameter-file-with-all-fields.yaml
@@ -5,6 +5,6 @@ ComponentDescription: Test parameter file for Greengrass packages
 ComponentPublisher: Me
 ComponentVersion: '1.0.0'
 ComponentType: aws.greengrass.generic
-Parameters:
+TemplateParameters:
   one: 2
   red: blue

--- a/src/test/resources/recipes/sample-parameter-file-with-all-fields.yaml
+++ b/src/test/resources/recipes/sample-parameter-file-with-all-fields.yaml
@@ -1,0 +1,10 @@
+---
+RecipeFormatVersion: 2020-01-25
+ComponentName: Foo
+ComponentDescription: Test parameter file for Greengrass packages
+ComponentPublisher: Me
+ComponentVersion: '1.0.0'
+ComponentType: aws.greengrass.generic
+Parameters:
+  one: 2
+  red: blue

--- a/src/test/resources/recipes/sample-template-with-all-fields.json
+++ b/src/test/resources/recipes/sample-template-with-all-fields.json
@@ -5,52 +5,50 @@
   "ComponentPublisher": "Me",
   "ComponentVersion": "1.0.0",
   "ComponentType": "aws.greengrass.template",
-  "ComponentConfiguration": {
-    "ParameterSchema": {
-      "field1": {
-        "type": "string",
-        "required": true
-      },
-      "Field2": {
-        "type": "string",
-        "required": false,
-        "defaultValue": "Another string"
-      },
-      "field3": {
-        "type": "boolean",
-        "required": false,
-        "defaultValue": true
-      },
-      "Field4": {
-        "type": "boolean",
-        "required": true
-      },
-      "field5": {
-        "type": "object",
-        "required": false,
-        "defaultValue": {
-          "key1": "val1",
-          "key2": {
-            "subkey1": 1,
-            "subkey2": "two"
-          }
+  "ParameterSchema": {
+    "field1": {
+      "type": "string",
+      "required": true
+    },
+    "Field2": {
+      "type": "string",
+      "required": false,
+      "defaultValue": "Another string"
+    },
+    "field3": {
+      "type": "boolean",
+      "required": false,
+      "defaultValue": true
+    },
+    "Field4": {
+      "type": "boolean",
+      "required": true
+    },
+    "field5": {
+      "type": "object",
+      "required": false,
+      "defaultValue": {
+        "key1": "val1",
+        "key2": {
+          "subkey1": 1,
+          "subkey2": "two"
         }
-      },
-      "field6": {
-        "type": "array",
-        "required": false,
-        "defaultValue": [
-          1,
-          2,
-          "red",
-          "blue"
-        ]
-      },
-      "field7": {
-        "type": "number",
-        "required": false,
-        "defaultValue": 7
       }
+    },
+    "field6": {
+      "type": "array",
+      "required": false,
+      "defaultValue": [
+        1,
+        2,
+        "red",
+        "blue"
+      ]
+    },
+    "field7": {
+      "type": "number",
+      "required": false,
+      "defaultValue": 7
     }
   },
   "Manifests": [

--- a/src/test/resources/recipes/sample-template-with-all-fields.json
+++ b/src/test/resources/recipes/sample-template-with-all-fields.json
@@ -6,24 +6,6 @@
   "ComponentVersion": "1.0.0",
   "ComponentType": "aws.greengrass.template",
   "ComponentConfiguration": {
-    "DefaultParameters": {
-      "Field2": "Another string",
-      "field3": true,
-      "field5": {
-        "key1": "val1",
-        "key2": {
-          "subkey1": 1,
-          "subkey2": "two"
-        }
-      },
-      "field6": [
-        1,
-        2,
-        "red",
-        "blue"
-      ],
-      "field7": 7
-    },
     "ParameterSchema": {
       "field1": {
         "type": "string",
@@ -31,11 +13,13 @@
       },
       "Field2": {
         "type": "string",
-        "required": false
+        "required": false,
+        "defaultValue": "Another string"
       },
       "field3": {
         "type": "boolean",
-        "required": false
+        "required": false,
+        "defaultValue": true
       },
       "Field4": {
         "type": "boolean",
@@ -43,15 +27,29 @@
       },
       "field5": {
         "type": "object",
-        "required": false
+        "required": false,
+        "defaultValue": {
+          "key1": "val1",
+          "key2": {
+            "subkey1": 1,
+            "subkey2": "two"
+          }
+        }
       },
       "field6": {
         "type": "array",
-        "required": false
+        "required": false,
+        "defaultValue": [
+          1,
+          2,
+          "red",
+          "blue"
+        ]
       },
       "field7": {
         "type": "number",
-        "required": false
+        "required": false,
+        "defaultValue": 7
       }
     }
   },

--- a/src/test/resources/recipes/sample-template-with-all-fields.json
+++ b/src/test/resources/recipes/sample-template-with-all-fields.json
@@ -1,0 +1,66 @@
+{
+  "RecipeFormatVersion": "2020-01-25",
+  "ComponentName": "FooTemplate",
+  "ComponentDescription": "Test template for Greengrass packages",
+  "ComponentPublisher": "Me",
+  "ComponentVersion": "1.0.0",
+  "ComponentType": "aws.greengrass.template",
+  "ComponentConfiguration": {
+    "DefaultParameters": {
+      "Field2": "Another string",
+      "field3": true,
+      "field5": {
+        "key1": "val1",
+        "key2": {
+          "subkey1": 1,
+          "subkey2": "two"
+        }
+      },
+      "field6": [
+        1,
+        2,
+        "red",
+        "blue"
+      ],
+      "field7": 7
+    },
+    "ParameterSchema": {
+      "field1": {
+        "type": "string",
+        "required": true
+      },
+      "Field2": {
+        "type": "string",
+        "required": false
+      },
+      "field3": {
+        "type": "boolean",
+        "required": false
+      },
+      "Field4": {
+        "type": "boolean",
+        "required": true
+      },
+      "field5": {
+        "type": "object",
+        "required": false
+      },
+      "field6": {
+        "type": "array",
+        "required": false
+      },
+      "field7": {
+        "type": "number",
+        "required": false
+      }
+    }
+  },
+  "Manifests": [
+    {
+      "Name": "All platforms",
+      "Platform": {
+        "os": "all"
+      }
+    }
+  ]
+}

--- a/src/test/resources/recipes/sample-template-with-all-fields.json
+++ b/src/test/resources/recipes/sample-template-with-all-fields.json
@@ -5,7 +5,7 @@
   "ComponentPublisher": "Me",
   "ComponentVersion": "1.0.0",
   "ComponentType": "aws.greengrass.template",
-  "ParameterSchema": {
+  "TemplateParameterSchema": {
     "field1": {
       "type": "string",
       "required": true

--- a/src/test/resources/recipes/sample-template-with-all-fields.yaml
+++ b/src/test/resources/recipes/sample-template-with-all-fields.yaml
@@ -6,7 +6,7 @@ ComponentPublisher: Me
 ComponentVersion: '1.0.0'
 ComponentType: aws.greengrass.template
 # no configuration
-ParameterSchema:
+TemplateParameterSchema:
   field1:
     type: string
     required: true

--- a/src/test/resources/recipes/sample-template-with-all-fields.yaml
+++ b/src/test/resources/recipes/sample-template-with-all-fields.yaml
@@ -5,42 +5,42 @@ ComponentDescription: Test template for Greengrass packages
 ComponentPublisher: Me
 ComponentVersion: '1.0.0'
 ComponentType: aws.greengrass.template
-ComponentConfiguration:
-  ParameterSchema:
-    field1:
-      type: string
-      required: true
-    Field2:
-      type: string
-      required: false
-      defaultValue: Another string
-    field3:
-      type: boolean
-      required: false
-      defaultValue: true
-    Field4:
-      type: boolean
-      required: true
-    field5:
-      type: object
-      required: false
-      defaultValue:
-        key1: val1
-        key2:
-          subkey1: 1
-          subkey2: two
-    field6:
-      type: array
-      required: false
-      defaultValue:
-        - 1
-        - 2
-        - red
-        - blue
-    field7:
-      type: number
-      required: false
-      defaultValue: 7
+# no configuration
+ParameterSchema:
+  field1:
+    type: string
+    required: true
+  Field2:
+    type: string
+    required: false
+    defaultValue: Another string
+  field3:
+    type: boolean
+    required: false
+    defaultValue: true
+  Field4:
+    type: boolean
+    required: true
+  field5:
+    type: object
+    required: false
+    defaultValue:
+      key1: val1
+      key2:
+        subkey1: 1
+        subkey2: two
+  field6:
+    type: array
+    required: false
+    defaultValue:
+      - 1
+      - 2
+      - red
+      - blue
+  field7:
+    type: number
+    required: false
+    defaultValue: 7
 # no dependencies
 Manifests:
   - Name: All platforms

--- a/src/test/resources/recipes/sample-template-with-all-fields.yaml
+++ b/src/test/resources/recipes/sample-template-with-all-fields.yaml
@@ -6,20 +6,6 @@ ComponentPublisher: Me
 ComponentVersion: '1.0.0'
 ComponentType: aws.greengrass.template
 ComponentConfiguration:
-  DefaultParameters:
-    Field2: Another string
-    field3: true
-    field5:
-      key1: val1
-      key2:
-        subkey1: 1
-        subkey2: two
-    field6:
-      - 1
-      - 2
-      - red
-      - blue
-    field7: 7
   ParameterSchema:
     field1:
       type: string
@@ -27,21 +13,34 @@ ComponentConfiguration:
     Field2:
       type: string
       required: false
+      defaultValue: Another string
     field3:
       type: boolean
       required: false
+      defaultValue: true
     Field4:
       type: boolean
       required: true
     field5:
       type: object
       required: false
+      defaultValue:
+        key1: val1
+        key2:
+          subkey1: 1
+          subkey2: two
     field6:
       type: array
       required: false
+      defaultValue:
+        - 1
+        - 2
+        - red
+        - blue
     field7:
       type: number
       required: false
+      defaultValue: 7
 # no dependencies
 Manifests:
   - Name: All platforms

--- a/src/test/resources/recipes/sample-template-with-all-fields.yaml
+++ b/src/test/resources/recipes/sample-template-with-all-fields.yaml
@@ -1,0 +1,50 @@
+---
+RecipeFormatVersion: 2020-01-25
+ComponentName: FooTemplate
+ComponentDescription: Test template for Greengrass packages
+ComponentPublisher: Me
+ComponentVersion: '1.0.0'
+ComponentType: aws.greengrass.template
+ComponentConfiguration:
+  DefaultParameters:
+    Field2: Another string
+    field3: true
+    field5:
+      key1: val1
+      key2:
+        subkey1: 1
+        subkey2: two
+    field6:
+      - 1
+      - 2
+      - red
+      - blue
+    field7: 7
+  ParameterSchema:
+    field1:
+      type: string
+      required: true
+    Field2:
+      type: string
+      required: false
+    field3:
+      type: boolean
+      required: false
+    Field4:
+      type: boolean
+      required: true
+    field5:
+      type: object
+      required: false
+    field6:
+      type: array
+      required: false
+    field7:
+      type: number
+      required: false
+# no dependencies
+Manifests:
+  - Name: All platforms
+    Platform:
+      os: all
+# no lifecycle

--- a/src/test/resources/recipes/template-recipe-bad-schema-type.yaml
+++ b/src/test/resources/recipes/template-recipe-bad-schema-type.yaml
@@ -1,0 +1,19 @@
+---
+RecipeFormatVersion: 2020-01-25
+ComponentName: FooTemplate
+ComponentDescription: Test recipe for Greengrass packages
+ComponentVersion: '1.0.0'
+ComponentType: aws.greengrass.template
+ComponentConfiguration:
+  ParameterSchema:
+    goodParameter:
+      type: string
+      required: true
+    badParameter:
+      type: not-a-real-type
+      required: false
+# No ComponentDependencies
+Manifests:
+  - Platform:
+      os: '*'
+    Lifecycle:

--- a/src/test/resources/recipes/template-recipe-bad-schema-type.yaml
+++ b/src/test/resources/recipes/template-recipe-bad-schema-type.yaml
@@ -4,7 +4,7 @@ ComponentName: FooTemplate
 ComponentDescription: Test recipe for Greengrass packages
 ComponentVersion: '1.0.0'
 ComponentType: aws.greengrass.template
-ParameterSchema:
+TemplateParameterSchema:
   goodParameter:
     type: string
     required: true

--- a/src/test/resources/recipes/template-recipe-bad-schema-type.yaml
+++ b/src/test/resources/recipes/template-recipe-bad-schema-type.yaml
@@ -12,6 +12,7 @@ ComponentConfiguration:
     badParameter:
       type: not-a-real-type
       required: false
+      defaultValue: ooga booga
 # No ComponentDependencies
 Manifests:
   - Platform:

--- a/src/test/resources/recipes/template-recipe-bad-schema-type.yaml
+++ b/src/test/resources/recipes/template-recipe-bad-schema-type.yaml
@@ -4,15 +4,14 @@ ComponentName: FooTemplate
 ComponentDescription: Test recipe for Greengrass packages
 ComponentVersion: '1.0.0'
 ComponentType: aws.greengrass.template
-ComponentConfiguration:
-  ParameterSchema:
-    goodParameter:
-      type: string
-      required: true
-    badParameter:
-      type: not-a-real-type
-      required: false
-      defaultValue: ooga booga
+ParameterSchema:
+  goodParameter:
+    type: string
+    required: true
+  badParameter:
+    type: not-a-real-type
+    required: false
+    defaultValue: ooga booga
 # No ComponentDependencies
 Manifests:
   - Platform:


### PR DESCRIPTION
**Issue #, if available:**
[P49759307] Add needed structures to EvergreenComponentsCommon repos
**Description of changes:**
Add `aws.greengrass.template` type. Add `TemplateParameter` structure and add `defaultParameters`, `parameterSchema` field to `ComponentConfiguration`.

**Why is this change necessary:**
Necessary for cleaner logic for recipe templating

**How was this change tested:**
Only deserialization tested, since the new features should never be written to a file, only consumed by a deployment.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
