### PR TITLE
refactor: parameter schema key to be a separate class

### DIFF
--- a/src/main/java/com/amazon/aws/iot/greengrass/component/common/ComponentRecipe.java
+++ b/src/main/java/com/amazon/aws/iot/greengrass/component/common/ComponentRecipe.java
@@ -50,7 +50,7 @@ public class ComponentRecipe {
 
     ComponentConfiguration componentConfiguration;
 
-    Map<String, TemplateParameter> templateParameterSchema;
+    TemplateParameterSchema templateParameterSchema;
 
     Map<String, Object> templateParameters;
 

--- a/src/main/java/com/amazon/aws/iot/greengrass/component/common/TemplateParameterSchema.java
+++ b/src/main/java/com/amazon/aws/iot/greengrass/component/common/TemplateParameterSchema.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.aws.iot.greengrass.component.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TemplateParameterSchema extends HashMap<String, TemplateParameter> {
+    private static final long serialVersionUID = -5896184342259928914L;
+
+    public TemplateParameterSchema(Map<String, TemplateParameter> other) {
+        super(other);
+    }
+
+    public TemplateParameterSchema() {
+        super();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof Map)) {
+            return false;
+        }
+        Map other = (Map) o;
+        if (this.size() != other.size()) {
+            return false;
+        }
+        for (Map.Entry<String, TemplateParameter> e : this.entrySet()) {
+            if (other.get(e.getKey()) == null || !e.getValue().equals(other.get(e.getKey()))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @SuppressWarnings("PMD.UselessOverridingMethod")
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append('{');
+        for (Map.Entry<String, TemplateParameter> e : this.entrySet()) {
+            builder.append(" \"").append(e.getKey()).append("\": ");
+            builder.append(e.getValue().toString());
+            builder.append(',');
+        }
+        builder.append(" }");
+        return builder.toString();
+    }
+}

--- a/src/test/java/com/amazon/aws/iot/greengrass/component/common/ComponentRecipeDeserializationTest.java
+++ b/src/test/java/com/amazon/aws/iot/greengrass/component/common/ComponentRecipeDeserializationTest.java
@@ -344,7 +344,7 @@ class ComponentRecipeDeserializationTest extends BaseRecipeTest {
         assertThat(recipe.getComponentConfiguration(), IsNull.nullValue());
 
         // parameter schema
-        Map<String, TemplateParameter> parameterSchemaMap = recipe.getTemplateParameterSchema();
+        TemplateParameterSchema parameterSchemaMap = recipe.getTemplateParameterSchema();
         assertEquals(parameterSchemaMap.size(), 7);
         assertEquals(parameterSchemaMap.get("field1"),
                 TemplateParameter.builder().type(TemplateParameterType.STRING).required(true).defaultValue(null).build());


### PR DESCRIPTION
**Issue #, if available:**
[Greenseer-327]

**Description of changes:**
Added a wrapper class for parameter schema that implements `equals` and `toString`.

**Why is this change necessary:**
Both these methods are used in multiple places in `nucleus`.

**How was this change tested:**
Existing tests.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
